### PR TITLE
Fix build error, update to Leptos 0.5-rc1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ categories = [
 cfg-if = "1"
 js-sys = "0.3.61"
 json-patch = "1.0.0"
-leptos = { version = "0.5.0-beta2", default-features = false }
+leptos = { version = "0.5.0-rc1", default-features = false }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0"
 wasm-bindgen = { version = "0.2.84", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ where
                     });
                 }
                 None => {
-                    leptos::error!(
+                    leptos::logging::error!(
                         r#"server signal was used without a SSE being provided.
 
 Ensure you call `leptos_sse::provide_sse("http://localhost:3000/sse")` at the highest level in your app."#


### PR DESCRIPTION
Leptos 0.5-rc1 moved the `error` macro into the `logging` namespace.
This PR fixes that and at the same time updates the leptos dependency to `0.5-rc1`.