### PR TITLE
Port patch#9 from `leptos_server_signal`

### DIFF
--- a/src/actix.rs
+++ b/src/actix.rs
@@ -20,7 +20,7 @@ pin_project! {
     /// A signal owned by the server which writes to the SSE when mutated.
     #[derive(Clone, Debug)]
     pub struct ServerSentEvents<S> {
-        event: Cow<'static, str>,
+        name: Cow<'static, str>,
         #[pin]
         stream: S,
         json_value: Value,
@@ -31,13 +31,13 @@ impl<S> ServerSentEvents<S> {
     /// Create a new [`ServerSentEvents`] a stream, initializing `T` to default.
     ///
     /// This function can fail if serilization of `T` fails.
-    pub fn new<T>(event: impl Into<Cow<'static, str>>, stream: S) -> Result<Self, serde_json::Error>
+    pub fn new<T>(name: impl Into<Cow<'static, str>>, stream: S) -> Result<Self, serde_json::Error>
     where
         T: Default + Serialize,
         S: TryStream<Ok = T, Error = BoxError>,
     {
         Ok(ServerSentEvents {
-            event: event.into(),
+            name: name.into(),
             stream,
             json_value: serde_json::to_value(T::default())?,
         })
@@ -49,7 +49,7 @@ impl<S> ServerSentEvents<S> {
     ///
     /// The first item in the tuple is the MPSC channel sender half.
     pub fn channel<T>(
-        event: impl Into<Cow<'static, str>>,
+        name: impl Into<Cow<'static, str>>,
         buffer: usize,
     ) -> Result<
         (
@@ -63,7 +63,7 @@ impl<S> ServerSentEvents<S> {
     {
         let (sender, receiver) = mpsc::channel::<T>(buffer);
         let stream = ReceiverStream::new(receiver).map(Ok);
-        Ok((Sender(sender), ServerSentEvents::new(event, stream)?))
+        Ok((Sender(sender), ServerSentEvents::new(name, stream)?))
     }
 }
 
@@ -82,10 +82,13 @@ where
         match this.stream.try_poll_next(cx) {
             Poll::Ready(Some(Ok(value))) => {
                 let new_json = serde_json::to_value(value)?;
-                let update =
-                    ServerSignalUpdate::new_from_json::<S::Item>(this.json_value, &new_json);
+                let update = ServerSignalUpdate::new_from_json::<S::Item>(
+                    this.name.clone(),
+                    this.json_value,
+                    &new_json,
+                );
                 *this.json_value = new_json;
-                let event = Event::Data(sse::Data::new_json(update)?.event(this.event.as_ref()));
+                let event = Event::Data(sse::Data::new_json(update)?);
                 Poll::Ready(Some(Ok(event)))
             }
             Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -17,7 +17,7 @@ pin_project! {
     /// A signal owned by the server which writes to the SSE when mutated.
     #[derive(Clone, Debug)]
     pub struct ServerSentEvents<S> {
-        event: Cow<'static, str>,
+        name: Cow<'static, str>,
         #[pin]
         stream: S,
         json_value: Value,
@@ -28,13 +28,13 @@ impl<S> ServerSentEvents<S> {
     /// Create a new [`ServerSentEvents`] a stream, initializing `T` to default.
     ///
     /// This function can fail if serilization of `T` fails.
-    pub fn new<T>(event: impl Into<Cow<'static, str>>, stream: S) -> Result<Self, serde_json::Error>
+    pub fn new<T>(name: impl Into<Cow<'static, str>>, stream: S) -> Result<Self, serde_json::Error>
     where
         T: Default + Serialize,
         S: TryStream<Ok = T, Error = axum::BoxError>,
     {
         Ok(ServerSentEvents {
-            event: event.into(),
+            name: name.into(),
             stream,
             json_value: serde_json::to_value(T::default())?,
         })
@@ -46,7 +46,7 @@ impl<S> ServerSentEvents<S> {
     ///
     /// The first item in the tuple is the MPSC channel sender half.
     pub fn channel<T>(
-        event: impl Into<Cow<'static, str>>,
+        name: impl Into<Cow<'static, str>>,
         buffer: usize,
     ) -> Result<
         (
@@ -60,7 +60,7 @@ impl<S> ServerSentEvents<S> {
     {
         let (sender, receiver) = mpsc::channel::<T>(buffer);
         let stream = ReceiverStream::new(receiver).map(Ok);
-        Ok((Sender(sender), ServerSentEvents::new(event, stream)?))
+        Ok((Sender(sender), ServerSentEvents::new(name, stream)?))
     }
 }
 
@@ -79,10 +79,13 @@ where
         match this.stream.try_poll_next(cx) {
             Poll::Ready(Some(Ok(value))) => {
                 let new_json = serde_json::to_value(value)?;
-                let update =
-                    ServerSignalUpdate::new_from_json::<S::Item>(this.json_value, &new_json);
+                let update = ServerSignalUpdate::new_from_json::<S::Item>(
+                    this.name.clone(),
+                    this.json_value,
+                    &new_json,
+                );
                 *this.json_value = new_json;
-                let event = Event::default().event(this.event).json_data(update)?;
+                let event = Event::default().json_data(update)?;
                 Poll::Ready(Some(Ok(event)))
             }
             Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,25 +28,36 @@ cfg_if::cfg_if! {
 /// This is whats sent over the SSE, and is used to patch the signal.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServerSignalUpdate {
+    name: Cow<'static, str>,
     patch: Patch,
 }
 
 impl ServerSignalUpdate {
     /// Creates a new [`ServerSignalUpdate`] from an old and new instance of `T`.
-    pub fn new<'s, 'e, T>(old: &'s T, new: &'e T) -> Result<Self, serde_json::Error>
+    pub fn new<T>(
+        name: impl Into<Cow<'static, str>>,
+        old: &T,
+        new: &T,
+    ) -> Result<Self, serde_json::Error>
     where
         T: Serialize,
     {
         let left = serde_json::to_value(old)?;
         let right = serde_json::to_value(new)?;
         let patch = json_patch::diff(&left, &right);
-        Ok(ServerSignalUpdate { patch })
+        Ok(ServerSignalUpdate {
+            name: name.into(),
+            patch,
+        })
     }
 
     /// Creates a new [`ServerSignalUpdate`] from two json values.
-    pub fn new_from_json<'s, 'e, T>(old: &Value, new: &Value) -> Self {
+    pub fn new_from_json<T>(name: impl Into<Cow<'static, str>>, old: &Value, new: &Value) -> Self {
         let patch = json_patch::diff(old, new);
-        ServerSignalUpdate { patch }
+        ServerSignalUpdate {
+            name: name.into(),
+            patch,
+        }
     }
 }
 
@@ -63,7 +74,7 @@ impl ServerSignalUpdate {
 /// pub fn App() -> impl IntoView {
 ///     // Provide SSE connection
 ///     leptos_sse::provide_sse("http://localhost:3000/sse").unwrap();
-///     
+///
 ///     // ...
 /// }
 /// ```
@@ -96,51 +107,38 @@ pub fn provide_sse(url: &str) -> Result<(), JsValue> {
 /// }
 /// ```
 #[allow(unused_variables)]
-pub fn create_sse_signal<T>(event: impl Into<Cow<'static, str>>) -> ReadSignal<T>
+pub fn create_sse_signal<T>(name: impl Into<Cow<'static, str>>) -> ReadSignal<T>
 where
     T: Default + Serialize + for<'de> Deserialize<'de>,
 {
-    let event_name = event.into();
+    let name = name.into();
     let (get, set) = create_signal(T::default());
 
     cfg_if::cfg_if! {
         if #[cfg(target_arch = "wasm32")] {
-            use web_sys::MessageEvent;
-            use wasm_bindgen::{prelude::Closure, JsCast};
-            use leptos::{use_context, create_effect, SignalGetUntracked, SignalSet, SignalUpdate};
-            use js_sys::{Function, JsString};
+            use leptos::{use_context, create_effect, create_rw_signal, SignalSet, SignalGet};
 
-            let (json_get, json_set) = create_signal(serde_json::to_value(T::default()).unwrap());
-            let ws = use_context::<ServerSignalEventSource>();
+            let signal = create_rw_signal(serde_json::to_value(T::default()).unwrap());
+            if let Some(ServerSignalEventSource { state_signals, .. }) = use_context::<ServerSignalEventSource>() {
+                let name: Cow<'static, str> = name.into();
+                state_signals.borrow_mut().insert(name.clone(), signal);
 
-            match ws {
-                Some(ServerSignalEventSource(es)) => {
-                    create_effect(move |_| {
-                        let event_name = event_name.clone();
-                        let callback = Closure::wrap(Box::new(move |event: MessageEvent| {
-                            let ws_string = event.data().dyn_into::<JsString>().unwrap().as_string().unwrap();
-                            if let Ok(update_signal) = serde_json::from_str::<ServerSignalUpdate>(&ws_string) {
-                                json_set.update(|doc| {
-                                    json_patch::patch(doc, &update_signal.patch).unwrap();
-                                });
-                                let new_value = serde_json::from_value(json_get.get_untracked()).unwrap();
-                                set.set(new_value);
-                            }
-                        }) as Box<dyn FnMut(_)>);
-                        let function: &Function = callback.as_ref().unchecked_ref();
-                        es.add_event_listener_with_callback(&event_name, function).unwrap();
+                // Note: The leptos docs advise against doing this. It seems to work
+                // well in testing, and the primary caveats are around unnecessary
+                // updates firing, but our state synchronization already prevents
+                // that on the server side
+                create_effect(move |_| {
+                    let name = name.clone();
+                    let new_value = serde_json::from_value(signal.get()).unwrap();
+                    set.set(new_value);
+                });
 
-                        // Keep the closure alive for the lifetime of the program
-                        callback.forget();
-                    });
-                }
-                None => {
-                    leptos::logging::error!(
-                        r#"server signal was used without a SSE being provided.
+            } else {
+                leptos::logging::error!(
+                    r#"server signal was used without a SSE being provided.
 
 Ensure you call `leptos_sse::provide_sse("http://localhost:3000/sse")` at the highest level in your app."#
-                    );
-                }
+                );
             }
         }
     }
@@ -150,18 +148,70 @@ Ensure you call `leptos_sse::provide_sse("http://localhost:3000/sse")` at the hi
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
+        use std::cell::RefCell;
+        use std::collections::HashMap;
+        use std::rc::Rc;
+
         use web_sys::EventSource;
-        use leptos::{provide_context, use_context};
+        use leptos::{provide_context, RwSignal};
 
         #[derive(Clone, Debug, PartialEq, Eq)]
-        struct ServerSignalEventSource(EventSource);
+        struct ServerSignalEventSource {
+            inner: EventSource,
+            // References to these are kept by the closure for the callback
+            // onmessage callback on the event source
+            state_signals: Rc<RefCell<HashMap<Cow<'static, str>, RwSignal<Value>>>>,
+            // When the event source is first established, leptos may not have
+            // completed the traversal that sets up all of the state signals.
+            // Without that, we don't have a base state to apply the patches to,
+            // and therefore we must keep a record of the patches to apply after
+            // the state has been set up.
+            delayed_updates: Rc<RefCell<HashMap<Cow<'static, str>, Vec<Patch>>>>,
+        }
 
         #[inline]
         fn provide_sse_inner(url: &str) -> Result<(), JsValue> {
+            use web_sys::MessageEvent;
+            use wasm_bindgen::{prelude::Closure, JsCast};
+            use leptos::{use_context, SignalUpdate};
+            use js_sys::{Function, JsString};
+
             if use_context::<ServerSignalEventSource>().is_none() {
-                let ws = EventSource::new(url)?;
-                provide_context(ServerSignalEventSource(ws));
+                let es = EventSource::new(url)?;
+                provide_context(ServerSignalEventSource { inner: es, state_signals: Default::default(), delayed_updates: Default::default() });
             }
+
+            let es = use_context::<ServerSignalEventSource>().unwrap();
+            let handlers = es.state_signals.clone();
+            let delayed_updates = es.delayed_updates.clone();
+            let callback = Closure::wrap(Box::new(move |event: MessageEvent| {
+                let ws_string = event.data().dyn_into::<JsString>().unwrap().as_string().unwrap();
+                if let Ok(update_signal) = serde_json::from_str::<ServerSignalUpdate>(&ws_string) {
+                    let handler_map = (*handlers).borrow();
+                    let name = &update_signal.name;
+                    let mut delayed_map = (*delayed_updates).borrow_mut();
+                    if let Some(signal) = handler_map.get(name) {
+                        if let Some(delayed_patches) = delayed_map.remove(name) {
+                            signal.update(|doc| {
+                                for patch in delayed_patches {
+                                    json_patch::patch(doc, &patch).unwrap();
+                                }
+                            });
+                        }
+                        signal.update(|doc| {
+                            json_patch::patch(doc, &update_signal.patch).unwrap();
+                        });
+                    } else {
+                        leptos::logging::warn!("No local state for update to {}. Queuing patch.", name);
+                        delayed_map.entry(name.clone()).or_default().push(update_signal.patch.clone());
+                    }
+                }
+            }) as Box<dyn FnMut(_)>);
+            let function: &Function = callback.as_ref().unchecked_ref();
+            es.inner.set_onmessage(Some(function));
+
+            // Keep the closure alive for the lifetime of the program
+            callback.forget();
 
             Ok(())
         }


### PR DESCRIPTION
fix: Multiple signals can now be registered, and state updates from the server that race signal creation on the client are now buffered to prevent state mismatch